### PR TITLE
Slippage percentage

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/pumpdotfun-go-sdk.iml" filepath="$PROJECT_DIR$/.idea/pumpdotfun-go-sdk.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/pumpdotfun-go-sdk.iml
+++ b/.idea/pumpdotfun-go-sdk.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="Go" enabled="true" />
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-  </component>
-</project>

--- a/buy.go
+++ b/buy.go
@@ -157,7 +157,7 @@ func getBuyInstructions(
 }
 
 func convertSlippageBasisPointsToPercentage(slippageBasisPoint uint) float64 {
-	return 1.0 - float64(slippageBasisPoint)/10e3
+	return 1.0 - float64(slippageBasisPoint)/100.0
 }
 
 // calculateBuyQuote calculates how many tokens can be purchased given a specific amount of SOL, bonding curve data, and percentage.

--- a/buy_test.go
+++ b/buy_test.go
@@ -36,15 +36,15 @@ func TestCalculateBuyQuote(t *testing.T) {
 
 func TestConvertSlippageBasisPointsToPercentage(t *testing.T) {
 	t.Parallel()
-	
+
 	tests := []struct {
 		name                string
 		slippageBasisPoints uint
 		expected            float64
 	}{
 		{"Zero slippage", 0, 1.0},
-		{"Two percent slippage", 200, 0.98},
-		{"Full slippage", 10000, 0.0},
+		{"Two percent slippage", 2, 0.98},
+		{"Full slippage", 100, 0.0},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary by Sourcery

Fix slippage conversion to use percentage points, update related tests, and remove IDE config files

Bug Fixes:
- Correct convertSlippageBasisPointsToPercentage to divide by 100 instead of 10000

Tests:
- Update TestConvertSlippageBasisPointsToPercentage to use percentage basis points values

Chores:
- Remove .idea IDE configuration files from the repository